### PR TITLE
Update to the latest travis_setup.sh for Scala Native

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ before_install:
   - test -f /tmp/chromedriver_download/chromedriver || (rm -rf /tmp/chromedriver_download; mkdir /tmp/chromedriver_download && wget https://chromedriver.storage.googleapis.com/2.31/chromedriver_linux64.zip -O /tmp/chromedriver_download/chromedriver_linux64.zip && test $(sha256sum /tmp/chromedriver_download/chromedriver_linux64.zip | cut -d' ' -f1) = 3e372ef676beb3a03aba72089ec0624bb9d3b52597635f907d4c23390fb485a0 && unzip /tmp/chromedriver_download/chromedriver_linux64.zip -d /tmp/chromedriver_download && chmod 777 /tmp/chromedriver_download/chromedriver)
   # install re2 like scala-native does but in /tmp so that it doesn't require
   # sudo:
-  # https://github.com/scala-native/scala-native/blob/master/bin/travis_setup.sh
+  # https://raw.githubusercontent.com/scala-native/scala-native/master/scripts/travis_setup.sh
   # We do this funny testing to see if the directory exists because if it exists
   # it means that it has been restored from the cache and thus we should not
   # have to do anything


### PR DESCRIPTION
[Recent PR](https://github.com/scala-native/scala-native/pull/1195) changed the location of the travis setup script within a Scala Native repo. This PR updates travis build to point to the new location.